### PR TITLE
Fix horizontal shifting on keyboard dismissal

### DIFF
--- a/Sources/KeyboardAccessory/UIBottomBar.Constraints.swift
+++ b/Sources/KeyboardAccessory/UIBottomBar.Constraints.swift
@@ -91,11 +91,11 @@ extension UIBottomBar {
                 // hostingView | keyboard (V)
                 barView.bottomAnchor.constraint(equalTo: keyboardLayoutGuide.topAnchor),
                 
-                // hostingView == keyboard (H)
-                barView.centerXAnchor.constraint(equalTo: keyboardLayoutGuide.centerXAnchor),
+                // hostingView == safeArea (H)
+                barView.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
                 {
-                    let constraint = barView.widthAnchor.constraint(equalTo: keyboardLayoutGuide.widthAnchor)
-                    constraint.priority -= 1
+                    let constraint = barView.widthAnchor.constraint(equalTo: safeAreaLayoutGuide.widthAnchor)
+                    constraint.priority = .defaultHigh - 1
                     return constraint
                 }(),
                 


### PR DESCRIPTION
There was an issue where the content of the keyboard accessory shifts off-screen (to the left) when the keyboard is fully dismissed.

The problem stemmed from the accessory’s horizontal positioning being anchored to the keyboard layout guide, which becomes unstable upon complete dismissal. Changes in this PR should fix that.

---

Before:

https://github.com/user-attachments/assets/0b48adfd-2e8a-4bde-913f-cfea1d0a3bfb

After:

https://github.com/user-attachments/assets/ed02cf29-512c-4f5f-a28a-2f0397a865fb

